### PR TITLE
Expand testing to more companies and all pages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
     only:
       - master
 
-  version: 1.4.0
+  version: 1.4.1
 
   install:
     - ps : .\environment-install.ps1

--- a/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
+++ b/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
@@ -7,6 +7,7 @@ namespace LiberisLabs.CompaniesHouse.IntegrationTests.Tests.CompanyFilingHistory
     {
         private const string InvalidCompanyNumber = "ABC00000";
 
+        [Test]
         protected override void When()
         {
             WhenRetrievingAnCompanyFilingHistoryForAnInvalidCompany();

--- a/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
+++ b/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
@@ -7,7 +7,6 @@ namespace LiberisLabs.CompaniesHouse.IntegrationTests.Tests.CompanyFilingHistory
     {
         private const string InvalidCompanyNumber = "ABC00000";
 
-        [SetUp]
         protected override void When()
         {
             WhenRetrievingAnCompanyFilingHistoryForAnInvalidCompany();

--- a/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
+++ b/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsInvalid.cs
@@ -7,7 +7,7 @@ namespace LiberisLabs.CompaniesHouse.IntegrationTests.Tests.CompanyFilingHistory
     {
         private const string InvalidCompanyNumber = "ABC00000";
 
-        [Test]
+        [SetUp]
         protected override void When()
         {
             WhenRetrievingAnCompanyFilingHistoryForAnInvalidCompany();

--- a/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsValid.cs
+++ b/src/LiberisLabs.CompaniesHouse.IntegrationTests/Tests/CompanyFilingHistoryTests/CompanyFilingHistoryTestsValid.cs
@@ -1,28 +1,41 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using System.Linq;
+using LiberisLabs.CompaniesHouse.Response.CompanyFiling;
+using NUnit.Framework;
 
 namespace LiberisLabs.CompaniesHouse.IntegrationTests.Tests.CompanyFilingHistoryTests
 {
     [TestFixture]
     public class CompanyFilingHistoryTestsValid : CompanyFilingHistoryTestBase
     {
-        // Google UK company number, unlikely to go away soon
-        private const string ValidCompanyNumber = "03977902";
+        public static string[] TestCases()
+        {
+            return new[]
+            {
+                "03977902", // Google
+                "00445790", // Tesco
+                "09965459"  // Amazebytes
+            };
+        }
 
-        [SetUp]
         protected override void When()
         {
-            WhenRetrievingAnCompanyFilingHistoryForAValidCompany();
         }
 
-        [Test]
-        public void ThenTheDataItemsAreNotEmpty()
+        [TestCaseSource(nameof(TestCases))]
+        public void ThenTheDataItemsAreNotEmpty(string testCase)
         {
-            Assert.That(_result.Data.Items, Is.Not.Empty);
-        }
+            var page = 0;
+            var size = 100;
+            var results = new List<FilingHistoryItem>();
 
-        private void WhenRetrievingAnCompanyFilingHistoryForAValidCompany()
-        {
-            _result = _client.GetCompanyFilingHistoryAsync(ValidCompanyNumber).Result;
+            do
+            {
+                _result = _client.GetCompanyFilingHistoryAsync(testCase, page++ * size, size).Result;
+                results.AddRange(_result.Data.Items);
+            } while (_result.Data.Items.Any());
+
+            Assert.That(results, Is.Not.Empty);
         }
     }
 }

--- a/src/LiberisLabs.CompaniesHouse/Response/FilingCategory.cs
+++ b/src/LiberisLabs.CompaniesHouse/Response/FilingCategory.cs
@@ -6,6 +6,9 @@ namespace LiberisLabs.CompaniesHouse.Response
     {
         None = 0,
 
+        [EnumMember(Value = "auditors")]
+        Auditors,
+
         [EnumMember(Value = "accounts")]
         Accounts,
 
@@ -37,6 +40,12 @@ namespace LiberisLabs.CompaniesHouse.Response
         Officers,
 
         [EnumMember(Value = "resolution")]
-        Resolution
+        Resolution,
+
+        [EnumMember(Value = "change-of-constitution")]
+        ChangeOfConstitution,
+
+        [EnumMember(Value = "document-replacement")]
+        DocumentReplacement
     }
 }

--- a/src/LiberisLabs.CompaniesHouse/Response/FilingSubcategory.cs
+++ b/src/LiberisLabs.CompaniesHouse/Response/FilingSubcategory.cs
@@ -6,11 +6,17 @@ namespace LiberisLabs.CompaniesHouse.Response
     {
         None = 0,
 
+        [EnumMember(Value = "annual-return")]
+        AnnualReturn,
+
         [EnumMember(Value = "resolution")]
         Resolution,
 
         [EnumMember(Value = "change")]
         Change,
+
+        [EnumMember(Value = "certificate")]
+        Certificate,
 
         [EnumMember(Value = "appointments")]
         Appointments,

--- a/src/LiberisLabs.CompaniesHouse/Response/ResolutionCategory.cs
+++ b/src/LiberisLabs.CompaniesHouse/Response/ResolutionCategory.cs
@@ -14,5 +14,8 @@ namespace LiberisLabs.CompaniesHouse.Response
 
         [EnumMember(Value = "miscellaneous")]
         Miscellaneous,
+
+        [EnumMember(Value = "resolution")]
+        Resolution
     }
 }


### PR DESCRIPTION
This is to catch all enumerations that are not documented on the official api page.

Resolves #17 